### PR TITLE
Switch to openssl to fix cert issue

### DIFF
--- a/tv.plex.PlexMediaPlayer.json
+++ b/tv.plex.PlexMediaPlayer.json
@@ -118,7 +118,7 @@
               "config-opts": [
                 "--enable-shared",
                 "--disable-static",
-                "--enable-gnutls",
+                "--enable-openssl",
                 "--enable-pic",
                 "--disable-doc",
                 "--disable-programs",


### PR DESCRIPTION
Fixes the error when trying to play videos that has come up because of the ssl certificate.

Resolves #9 