### PR TITLE
upgrade framework, sdk and dependencies to newer versions

### DIFF
--- a/modules/io.mpv.Mpv.yml
+++ b/modules/io.mpv.Mpv.yml
@@ -1,0 +1,420 @@
+name: mpv-deps
+buildsystem: simple
+build-commands:
+  - echo
+
+cleanup:
+  - '*.la'
+  - '*.a'
+
+modules:
+  - pipewire/pipewire-jack-runtime.json
+
+  - name: libXmu
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/freedesktop/libXmu/archive/libXmu-1.1.2.tar.gz
+        sha256: fb1485a0ffcc360c0cc8fe18f54a2f49af6fc384da743c0b136ab99cc6c6e54c
+
+  - name: xclip
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/astrand/xclip/archive/0.13.tar.gz
+        sha256: ca5b8804e3c910a66423a882d79bf3c9450b875ac8528791fb60ec9de667f758
+
+  - name: luajit
+    no-autogen: true
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: git
+        url: https://luajit.org/git/luajit-2.0.git
+        branch: v2.1
+        disable-shallow-clone: true
+      - type: shell
+        commands:
+          - sed -i 's|/usr/local|/app|' ./Makefile
+
+  - name: uchardet
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_STATIC=0
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: archive
+        url: https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.6.tar.xz
+        sha256: 8351328cdfbcb2432e63938721dd781eb8c11ebc56e3a89d0f84576b96002c61
+
+  - name: libass
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    config-opts:
+      - --disable-static
+    sources:
+      - type: archive
+        url: https://github.com/libass/libass/releases/download/0.15.0/libass-0.15.0.tar.gz
+        sha256: 9cbddee5e8c87e43a5fe627a19cd2aa4c36552156eb4edcf6c5a30bd4934fe58
+
+  - name: libcdio
+    config-opts:
+      - --disable-static
+      - --disable-example-progs
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://ftp.gnu.org/gnu/libcdio/libcdio-2.1.0.tar.bz2
+        sha256: 8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b
+        x-checker-data:
+          type: html
+          url: https://ftp.gnu.org/gnu/libcdio/
+          version-pattern: libcdio-(\d\.\d+\.?\d*).tar.bz2
+          url-template: https://ftp.gnu.org/gnu/libcdio/libcdio-$version.tar.bz2
+
+  - name: libcdio-paranoia
+    config-opts:
+      - --disable-static
+      - --disable-example-progs
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+2.0.1.tar.bz2
+        sha256: 33b1cf305ccfbfd03b43936975615000ce538b119989c4bec469577570b60e8a
+        x-checker-data:
+          type: html
+          url: https://ftp.gnu.org/gnu/libcdio/
+          version-pattern: libcdio-paranoia-([\d\.\+-]+).tar.bz2
+          url-template: https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-$version.tar.bz2
+
+  - name: libdvdread
+    config-opts:
+      - --disable-static
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://download.videolan.org/pub/videolan/libdvdread/6.1.1/libdvdread-6.1.1.tar.bz2
+        sha256: 3e357309a17c5be3731385b9eabda6b7e3fa010f46022a06f104553bf8e21796
+        x-checker-data:
+          type: html
+          url: https://www.videolan.org/developers/libdvdnav.html
+          version-pattern: The latest version of <code>libdvdread</code> is <b>([\d\-\.]+)<
+          url-template: https://download.videolan.org/pub/videolan/libdvdread/$version/libdvdread-$version.tar.bz2
+
+  - name: libdvdnav
+    config-opts:
+      - --disable-static
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://download.videolan.org/pub/videolan/libdvdnav/6.1.1/libdvdnav-6.1.1.tar.bz2
+        sha256: c191a7475947d323ff7680cf92c0fb1be8237701885f37656c64d04e98d18d48
+        x-checker-data:
+          type: html
+          url: https://www.videolan.org/developers/libdvdnav.html
+          version-pattern: The latest version of <code>libdvdnav</code> is <b>([\d\-\.]+)</b>\.
+          url-template: https://download.videolan.org/pub/videolan/libdvdnav/$version/libdvdnav-$version.tar.bz2
+
+  - name: libbluray
+    config-opts:
+      - --disable-static
+      - --disable-bdjava-jar
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - sha256: e2dbaf99e84e0a9725f4985bcb85d41e52c2261cc651d8884b1b790b5ef016f9
+        type: archive
+        url: https://download.videolan.org/pub/videolan/libbluray/1.3.0/libbluray-1.3.0.tar.bz2
+        x-checker-data:
+          type: html
+          url: https://www.videolan.org/developers/libbluray.html
+          version-pattern: Latest release is <b>libbluray (\d\.\d+\.?\d*)</b>\.
+          url-template: https://download.videolan.org/pub/videolan/libbluray/$version/libbluray-$version.tar.bz2
+
+  - name: zimg
+    config-opts:
+      - --disable-static
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/doc
+    sources:
+      - type: archive
+        archive-type: tar
+        url: https://api.github.com/repos/sekrit-twc/zimg/tarball/release-3.0.3
+        sha256: 6926aa9e27c8f6e4e26186292e253c918334e399b04b6a9490b8584328c7814f
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/sekrit-twc/zimg/releases/latest
+          url-query: .tarball_url
+          version-query: .tag_name | sub("^release-"; "")
+          timestamp-query: .published_at
+
+  - name: rubberband
+    buildsystem: meson
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://breakfastquay.com/files/releases/rubberband-2.0.2.tar.bz2
+        sha256: b9eac027e797789ae99611c9eaeaf1c3a44cc804f9c8a0441a0d1d26f3d6bdf9
+        x-checker-data:
+          type: html
+          url: https://www.breakfastquay.com/rubberband/
+          version-pattern: Rubber Band Library v(\d\.\d+\.?\d*) source
+          url-template: https://breakfastquay.com/files/releases/rubberband-$version.tar.bz2
+
+  - name: mujs
+    no-autogen: true
+    make-args:
+      - release
+      - shared
+    make-install-args:
+      - prefix=/app
+      - install-shared
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/ccxvii/mujs.git
+        tag: 1.2.0
+        commit: dd0a0972b4428771e6a3887da2210c7c9dd40f9c
+        x-checker-data:
+          type: git
+          url: https://api.github.com/repos/ccxvii/mujs/tags
+          tag-pattern: ^([\d.]+)$
+
+  - name: nv-codec-headers
+    cleanup:
+      - '*'
+    no-autogen: true
+    make-install-args:
+      - PREFIX=/app
+    sources:
+      - type: git
+        url: https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
+        tag: n11.1.5.1
+        commit: 84483da70d903239d4536763fde8c7e6c4e80784
+        x-checker-data:
+          type: git
+          tag-pattern: ^n([\d.]+)$
+
+  - name: x264
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    config-opts:
+      - --disable-cli
+      - --enable-shared
+
+    sources:
+      - type: git
+        url: https://code.videolan.org/videolan/x264.git
+        commit: 66a5bc1bd1563d8227d5d18440b525a09bcf17ca
+
+  - name: x265
+    buildsystem: cmake
+    subdir: source
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_STATIC=0
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: archive
+        url: https://bitbucket.org/multicoreware/x265_git/downloads/x265_3.5.tar.gz
+        md5: deb5df5cb2ec17bdbae6ac6bbc3b1eef
+
+  - name: ffmpeg
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/ffmpeg/examples
+    config-opts:
+      - --disable-static
+      - --disable-debug
+      - --disable-doc
+      - --disable-programs
+      - --enable-gnutls
+      - --enable-shared
+      - --enable-encoder=png
+      - --enable-libv4l2
+      - --enable-gpl
+      - --enable-version3
+      - --enable-libass
+      - --enable-libfreetype
+      - --enable-libmp3lame
+      - --enable-libopus
+      - --enable-libtheora
+      - --enable-libvorbis
+      - --enable-libvpx
+      - --enable-libaom
+      - --enable-libdav1d
+      - --enable-libx264
+      - --enable-libx265
+    sources:
+      - type: archive
+        url: https://ffmpeg.org/releases/ffmpeg-4.4.tar.xz
+        sha256: 06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909
+
+  - name: libsixel
+    buildsystem: meson
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        archive-type: tar
+        url: https://api.github.com/repos/libsixel/libsixel/tarball/refs/tags/v1.10.3
+        sha256: 7be774befba882d53701e131b6657836118f6cdb15a7515f92345c7bb6e2bb5c
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/libsixel/libsixel/tags
+          url-query: .[0].tarball_url
+          version-query: .[0].name
+
+  - name: vapoursynth
+    config-opts:
+      - --disable-static
+      - --with-python_prefix=/app
+    sources:
+      - type: git
+        url: https://github.com/vapoursynth/vapoursynth.git
+        tag: R57
+        commit: 325756ed04588b31840fdb74479537cddcba4bf7
+        x-checker-data:
+          type: git
+          tag-pattern: ^R([\d.]+)$
+
+  - name: libplacebo
+    buildsystem: meson
+    config-opts:
+      - -Dvulkan=enabled
+      - -Dshaderc=enabled
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://code.videolan.org/videolan/libplacebo.git
+        tag: v4.192.0
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
+        commit: f95f7aa2a23c818a1aea32754b7ff06cd5503fb7
+    modules:
+      - name: shaderc
+        buildsystem: cmake-ninja
+        builddir: true
+        config-opts:
+          - -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
+          - -DSHADERC_SKIP_EXAMPLES=ON
+          - -DSHADERC_SKIP_TESTS=ON
+        cleanup:
+          - /bin
+          - /include
+          - /lib/cmake
+          - /lib/pkgconfig
+        post-install:
+          # copy libSPIRV, as it's only available in Sdk
+          - install -D /lib/$(gcc --print-multiarch)/libSPIRV*.so /app/lib
+        sources:
+          - type: archive
+            archive-type: tar
+            url: https://api.github.com/repos/google/shaderc/tarball/refs/tags/v2021.3
+            sha256: b7e54b23a83343d5e2da836d8833ae0db11926141955edf845e35d4dc1eb88d1
+            x-checker-data:
+              type: json
+              url: https://api.github.com/repos/google/shaderc/tags
+              url-query: .[0].tarball_url
+              version-query: .[0].name
+          - type: shell
+            commands:
+              - sed -i 's|SPIRV/GlslangToSpv.h|glslang/SPIRV/GlslangToSpv.h|' libshaderc_util/src/compiler.cc
+              - sed -i 's|add_subdirectory(third_party)||' CMakeLists.txt
+              - sed -i 's|add_custom_target(build-version|set(NOT_USE|' CMakeLists.txt
+              - |
+                LIB=/lib/$(gcc --print-multiarch)
+                VER_MATCH="[0-9]+\.[^\. ]+"
+                SHADERC=$(grep -m1 -oP "^v$VER_MATCH" CHANGES)
+                SPIRV=v$(grep -oP "(?<=Version:.)$VER_MATCH" $LIB/pkgconfig/SPIRV-Tools-shared.pc)
+                GLSLANG=v$(realpath $LIB/libglslang.so | grep -oP "(?<=so.)$VER_MATCH")
+                cat <<- EOF > glslc/src/build-version.inc
+                  "shaderc $SHADERC"
+                  "spirv-tools $SPIRV"
+                  "glslang $GLSLANG"
+                EOF
+              - cat glslc/src/build-version.inc
+
+  - name: mpv
+    buildsystem: simple
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    build-commands:
+      - python3 waf configure --prefix=/app --enable-libmpv-shared --disable-build-date
+        --disable-manpage-build --disable-alsa --enable-sdl2 --enable-libarchive --enable-dvbin
+        --enable-cdda --enable-dvdnav --enable-shaderc --enable-vulkan
+      - python3 waf build
+      - python3 waf install
+    post-install:
+      # save screenshots at ~/Pictures/mpv
+      - echo "screenshot-directory=~/Pictures/mpv" > /app/etc/mpv/mpv.conf
+    sources:
+      - type: archive
+        url: https://github.com/mpv-player/mpv/archive/v0.34.1.tar.gz
+        sha256: 32ded8c13b6398310fa27767378193dc1db6d78b006b70dbcbd3123a1445e746
+      - type: file
+        url: https://waf.io/waf-2.0.22
+        sha256: 0a09ad26a2cfc69fa26ab871cb558165b60374b5a653ff556a0c6aca63a00df1
+        dest-filename: waf
+
+# Scripts for mpv
+  - name: mpv-mpris
+    no-autogen: true
+    make-install-args:
+      - SCRIPTS_DIR=/app/etc/mpv/scripts
+    sources:
+      - type: archive
+        archive-type: tar
+        url: https://api.github.com/repos/hoyon/mpv-mpris/tarball/0.6
+        sha256: e868babe6e8b2e395e5302a5398620da1f5d7026c8db6b24c16b0169b1533d0b
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/hoyon/mpv-mpris/releases/latest
+          version-query: .name
+          url-query: .tarball_url
+
+  - name: bc
+    build-options:
+      no-debuginfo: true
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://ftp.gnu.org/gnu/bc/bc-1.07.1.tar.gz
+        sha256: 62adfca89b0a1c0164c2cdca59ca210c1d44c3ffc46daf9931cf4942664cb02a
+

--- a/modules/pipewire/pipewire-jack-runtime-aarch64.pc
+++ b/modules/pipewire/pipewire-jack-runtime-aarch64.pc
@@ -1,0 +1,11 @@
+prefix=/app
+exec_prefix=/app
+libdir=/usr/lib/aarch64-linux-gnu/pipewire-0.3/jack
+includedir=/app/include
+server_libs=-L/usr/lib/aarch64-linux-gnu/pipewire-0.3/jack -ljackserver
+
+Name: jack
+Description: the Jack Audio Connection Kit: a low-latency synchronous callback-based media server
+Version: 1.9.16
+Libs: -L/usr/lib/aarch64-linux-gnu/pipewire-0.3/jack -ljack
+Cflags: -I/app/include

--- a/modules/pipewire/pipewire-jack-runtime-x86_64.pc
+++ b/modules/pipewire/pipewire-jack-runtime-x86_64.pc
@@ -1,0 +1,11 @@
+prefix=/app
+exec_prefix=/app
+libdir=/usr/lib/x86_64-linux-gnu/pipewire-0.3/jack
+includedir=/app/include
+server_libs=-L/usr/lib/x86_64-linux-gnu/pipewire-0.3/jack -ljackserver
+
+Name: jack
+Description: the Jack Audio Connection Kit: a low-latency synchronous callback-based media server
+Version: 1.9.16
+Libs: -L/usr/lib/x86_64-linux-gnu/pipewire-0.3/jack -ljack
+Cflags: -I/app/include

--- a/modules/pipewire/pipewire-jack-runtime.json
+++ b/modules/pipewire/pipewire-jack-runtime.json
@@ -1,0 +1,35 @@
+{
+    "name": "pipewire-jack-runtime",
+    "buildsystem": "simple",
+    "build-commands": [
+        "install -Dm644 *.h -t /app/include/jack/",
+        "install -Dm644 pipewire-jack-runtime.pc /app/lib/pkgconfig/jack.pc"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/jackaudio/headers",
+            "branch": "master",
+            "commit": "4e53c8f0a33e9ed87eac5ca6e578b7ee92a1fd3d"
+        },
+        {
+            "type": "file",
+            "only-arches": [
+                "x86_64"
+            ],
+            "dest-filename": "pipewire-jack-runtime.pc",
+            "path": "pipewire-jack-runtime-x86_64.pc"
+        },
+        {
+            "type": "file",
+            "only-arches": [
+                "aarch64"
+            ],
+            "dest-filename": "pipewire-jack-runtime.pc",
+            "path": "pipewire-jack-runtime-aarch64.pc"
+        }
+    ],
+    "cleanup": [
+        "*"
+    ]
+}

--- a/tv.plex.PlexMediaPlayer.json
+++ b/tv.plex.PlexMediaPlayer.json
@@ -1,8 +1,10 @@
 {
   "app-id": "tv.plex.PlexMediaPlayer",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.9",
+  "runtime-version": "5.15",
   "sdk": "org.kde.Sdk",
+  "base": "io.qt.qtwebengine.BaseApp",
+  "base-version": "5.15",
   "command": "plexmediaplayer",
   "finish-args": [
     "--socket=x11",
@@ -36,8 +38,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3.tar.gz",
-          "sha256": "0bd60d512275dc9f6ef2a2865426a184642ceb3761794e6b65bff233b91d8c40"
+          "url": "https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz",
+          "sha256": "0e998229549d7b3f368703d20e248e7ee1f853910d42704aa87918c213ea82c0"
         }
       ]
     },
@@ -63,7 +65,8 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/plexinc/plex-media-player.git"
+          "url": "https://github.com/plexinc/plex-media-player.git",
+          "tag": "v2.58.1-ae73e074"
         },
         {
           "type": "file",
@@ -87,13 +90,13 @@
           "sources": [
             {
               "type": "archive",
-              "url": "https://github.com/mpv-player/mpv/archive/v0.29.1.tar.gz",
-              "sha256": "f9f9d461d1990f9728660b4ccb0e8cb5dce29ccaa6af567bec481b79291ca623"
+              "url": "https://github.com/mpv-player/mpv/archive/v0.34.0.tar.gz",
+              "sha256": "f654fb6275e5178f57e055d20918d7d34e19949bc98ebbf4a7371902e88ce309"
             },
             {
               "type": "file",
-              "url": "https://waf.io/waf-2.0.9",
-              "sha256": "2a8e0816f023995e557f79ea8940d322bec18f286917c8f9a6fa2dc3875dfa48",
+              "url": "https://waf.io/waf-2.0.23",
+              "sha256": "28a2e4583314a162cfcbffefb8a9202c1d7869040d30b5852da479b76d9c0491",
               "dest-filename": "waf"
             }
           ],
@@ -108,8 +111,8 @@
               "sources": [
                 {
                   "type": "archive",
-                  "url": "https://github.com/FFmpeg/nv-codec-headers/releases/download/n8.2.15.8/nv-codec-headers-8.2.15.8.tar.gz",
-                  "sha256": "770b20b7e63adf84d42394b50425cf9ac7925913ac4f77faba552aa525dd437a"
+                  "url": "https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.1.5.0/nv-codec-headers-11.1.5.0.tar.gz",
+                  "sha256": "5b3692da3215006ea9fb5585b046605133cd111eb63e376feb5309ccb5ff13dc"
                 }
               ]
             },
@@ -132,8 +135,8 @@
               "cleanup": [ "/lib/pkgconfig", "/share", "/include" ],
               "sources": [{
                 "type": "archive",
-                "url": "https://ffmpeg.org/releases/ffmpeg-4.1.6.tar.xz",
-                "sha256": "1f7dc856850c6f5d6def660cb4429afcc60980b3a09815ee2e3e1421d75fdc62"
+                "url": "https://ffmpeg.org/releases/ffmpeg-4.4.1.tar.xz",
+                "sha256": "eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02"
               }]
             },
             {
@@ -146,8 +149,8 @@
               "sources": [
                 {
                   "type": "archive",
-                  "url": "https://github.com/libass/libass/releases/download/0.14.0/libass-0.14.0.tar.xz",
-                  "sha256": "881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
+                  "url": "https://github.com/libass/libass/releases/download/0.15.2/libass-0.15.2.tar.xz",
+                  "sha256": "1be2df9c4485a57d78bb18c0a8ed157bc87a5a8dd48c661961c625cb112832fd"
                 }
               ],
               "modules": [
@@ -157,8 +160,8 @@
                   "sources": [
                     {
                       "type": "archive",
-                      "url": "https://github.com/fribidi/fribidi/releases/download/0.19.7/fribidi-0.19.7.tar.bz2",
-                      "sha256": "08222a6212bbc2276a2d55c3bf370109ae4a35b689acbc66571ad2a670595a8e"
+                      "url": "https://github.com/fribidi/fribidi/releases/download/v1.0.11/fribidi-1.0.11.tar.xz",
+                      "sha256": "30f93e9c63ee627d1a2cedcf59ac34d45bf30240982f99e44c6e015466b4e73d"
                     }
                   ]
                 }

--- a/tv.plex.PlexMediaPlayer.json
+++ b/tv.plex.PlexMediaPlayer.json
@@ -25,6 +25,7 @@
     "strip": true
   },
   "modules": [
+    "modules/io.mpv.Mpv.yml",
     {
       "name": "plex-media-player",
       "buildsystem": "cmake-ninja",
@@ -57,116 +58,6 @@
         {
           "type": "file",
           "path": "tv.plex.PlexMediaPlayer.appdata.xml"
-        }
-      ],
-      "modules": [
-        {
-          "name": "mpv",
-          "buildsystem": "simple",
-          "build-commands": [
-            "python3 waf configure --prefix=/app --enable-libmpv-shared --disable-cplayer --disable-build-date --disable-manpage-build --enable-vaapi --enable-vdpau --enable-cuda-hwaccel --enable-pulse --enable-alsa --disable-oss-audio --disable-tv --enable-uchardet",
-            "python3 waf build",
-            "python3 waf install"
-          ],
-          "cleanup": [ "/lib/pkgconfig", "/share", "/include" ],
-          "sources": [
-            {
-              "type": "archive",
-              "url": "https://github.com/mpv-player/mpv/archive/v0.34.0.tar.gz",
-              "sha256": "f654fb6275e5178f57e055d20918d7d34e19949bc98ebbf4a7371902e88ce309"
-            },
-            {
-              "type": "file",
-              "url": "https://waf.io/waf-2.0.23",
-              "sha256": "28a2e4583314a162cfcbffefb8a9202c1d7869040d30b5852da479b76d9c0491",
-              "dest-filename": "waf"
-            }
-          ],
-          "modules": [
-            {
-              "name": "ffnvcodec",
-              "buildsystem": "simple",
-              "build-commands": [
-                  "make install PREFIX=/app"
-              ],
-              "cleanup": [ "/lib/pkgconfig", "/include" ],
-              "sources": [
-                {
-                  "type": "archive",
-                  "url": "https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.1.5.0/nv-codec-headers-11.1.5.0.tar.gz",
-                  "sha256": "5b3692da3215006ea9fb5585b046605133cd111eb63e376feb5309ccb5ff13dc"
-                }
-              ]
-            },
-            {
-              "name": "ffmpeg",
-              "config-opts": [
-                "--enable-shared",
-                "--disable-static",
-                "--enable-openssl",
-                "--enable-pic",
-                "--disable-doc",
-                "--disable-programs",
-                "--disable-encoders",
-                "--disable-muxers",
-                "--disable-devices",
-                "--enable-vaapi",
-                "--enable-vdpau",
-                "--enable-cuvid"
-              ],
-              "cleanup": [ "/lib/pkgconfig", "/share", "/include" ],
-              "sources": [{
-                "type": "archive",
-                "url": "https://ffmpeg.org/releases/ffmpeg-4.4.1.tar.xz",
-                "sha256": "eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02"
-              }]
-            },
-            {
-              "name": "libass",
-              "config-opts": [
-                "--enable-shared",
-                "--disable-static"
-              ],
-              "cleanup": [ "/lib/*.la", "/lib/pkgconfig", "/include" ],
-              "sources": [
-                {
-                  "type": "archive",
-                  "url": "https://github.com/libass/libass/releases/download/0.15.2/libass-0.15.2.tar.xz",
-                  "sha256": "1be2df9c4485a57d78bb18c0a8ed157bc87a5a8dd48c661961c625cb112832fd"
-                }
-              ],
-              "modules": [
-                {
-                  "name": "fribidi",
-                  "cleanup": [ "/bin", "/lib/*.la", "/lib/pkgconfig", "/share", "/include" ],
-                  "sources": [
-                    {
-                      "type": "archive",
-                      "url": "https://github.com/fribidi/fribidi/releases/download/v1.0.11/fribidi-1.0.11.tar.xz",
-                      "sha256": "30f93e9c63ee627d1a2cedcf59ac34d45bf30240982f99e44c6e015466b4e73d"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "uchardet",
-              "buildsystem": "cmake-ninja",
-              "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_INSTALL_LIBDIR=lib",
-                "-DBUILD_BINARY=OFF"
-              ],
-              "cleanup": [ "/lib/*.a", "/lib/pkgconfig", "/share", "/include" ],
-              "sources": [
-                {
-                  "type": "archive",
-                  "url": "https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.7.tar.xz",
-                  "sha256": "3fc79408ae1d84b406922fa9319ce005631c95ca0f34b205fad867e8b30e45b1"
-                }
-              ]
-            }
-          ]
         }
       ]
     }

--- a/tv.plex.PlexMediaPlayer.json
+++ b/tv.plex.PlexMediaPlayer.json
@@ -26,24 +26,6 @@
   },
   "modules": [
     {
-      "name": "cmake",
-      "buildsystem": "autotools",
-      "config-opts": [
-        "--prefix=/app",
-        "--",
-        "-DCMAKE_USE_OPENSSL=ON",
-        "-DBUILD_TESTING=OFF"
-      ],
-      "cleanup": [ "*" ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz",
-          "sha256": "0e998229549d7b3f368703d20e248e7ee1f853910d42704aa87918c213ea82c0"
-        }
-      ]
-    },
-    {
       "name": "plex-media-player",
       "buildsystem": "cmake-ninja",
       "build-options": {

--- a/tv.plex.PlexMediaPlayer.json
+++ b/tv.plex.PlexMediaPlayer.json
@@ -1,10 +1,10 @@
 {
   "app-id": "tv.plex.PlexMediaPlayer",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15",
+  "runtime-version": "5.15-21.08",
   "sdk": "org.kde.Sdk",
   "base": "io.qt.qtwebengine.BaseApp",
-  "base-version": "5.15",
+  "base-version": "5.15-21.08",
   "command": "plexmediaplayer",
   "finish-args": [
     "--socket=x11",


### PR DESCRIPTION
kde framework 5.9 is long deprecated and can be replaced with 5.15 + "io.qt.qtwebengine.BaseApp".
While testing I also upgraded a bunch of other dependencies.
